### PR TITLE
Construct bot with `Intents.none()`

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ load_dotenv()
 
 def main():
     token = os.environ.get('TOKEN')
-    bot = CoolBot(intents = discord.Intents.all())
+    bot = CoolBot(intents = discord.Intents.none())
     bot.intents.members = True
     bot.intents.presences = True
     bot.intents.guilds = True


### PR DESCRIPTION
I assume that the [explicit declaration here](https://github.com/SMANahian/cool-problem-bot/blob/master/main.py#L13-L16) enables all the intents the bot needs to operate.
However the [bot is constructed](https://github.com/SMANahian/cool-problem-bot/blob/master/main.py#L12) with all the intents enabled. This PR constructs the bot with no intents so the later lines actually only enable the 4 intents in question.

Note: If the bot actually needs all the intents as declared in the constructor, the explicit declaration of the 4 intents doesn't actually do anything, and should be removed.